### PR TITLE
Connect to reddit via https

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -10,7 +10,6 @@
    to the previous and next videos
 
 ** Routes
-   
    You can provide videos from a different subreddit by including it
    within the url like so --> http://benzap.github.io/redditv/#/r/AwfulCommercials
 
@@ -23,6 +22,14 @@
 
    Currently, it only supports youtube videos. I hope to expand on
    that in the future.
+
+** How to run
+   To start and connect your editor to the app, [follow these steps](https://github.com/plexus/chestnut#usage):
+
+   * `lein repl`
+   * Optionally connect with your editor - for emacs, `M-x cider-connect`
+   * In the repl, evaluate `(run)`
+   * Connect your browser to the url given in the repl. Something like `http://localhost:3449`
 
 ** Programming Tasks
    - [X] Keyboard Shortcuts to watch next video, or previous video

--- a/src/cljs/redditv/reddit.cljs
+++ b/src/cljs/redditv/reddit.cljs
@@ -4,7 +4,7 @@
             [redditv.jsonp :refer [send-jsonp]]
             [redditv.youtube :as yt]))
 
-(def reddit-url "http://www.reddit.com")
+(def reddit-url "https://www.reddit.com")
 
 (defn get-subreddit-posts [subreddit]
   (let [output-channel (chan)
@@ -29,8 +29,7 @@
     (go (let [posts (<! success-channel)
               videos (filterv post-is-video? posts)]
           (put! output-channel videos)))
-    [output-channel error-channel]
-    ))
+    [output-channel error-channel]))
 
 #_(let [[success error] (get-subreddit-videos "videos")]
     (go (let [result (<! success)]


### PR DESCRIPTION
I am a user of the extension called [HTTPS everywhere](https://www.eff.org/https-everywhere), and the app was failing. When disabling the extension, it worked. 

Added a small fix to load the reddit api via https, so that people listening in on the connection can't see what is being transmitted to the user, and so that the app works for those who don't connect to reddit via http. 
